### PR TITLE
Defining specific `openapi-generator-cli` Docker image

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -25,3 +25,4 @@ jobs:
         with:
           generator: java
           openapi-file: openapi.yaml
+          generator-tag: v6.6.0


### PR DESCRIPTION
Closes #3 

It seems that the [latest Docker image](https://hub.docker.com/r/openapitools/openapi-generator-cli/tags) is now pointing to a v7 snapshot version and it's breaking our [GitHub actions](https://github.com/FusionAuth/fusionauth-openapi/actions/runs/5204943545):

![image](https://github.com/FusionAuth/fusionauth-openapi/assets/1877191/b0ce8f6f-bfce-4b59-b51d-00db7995aaa8)

So I'm setting `openapi-generator-cli` Docker image to v6.6.0, which is the stable version.